### PR TITLE
Add next, previous, and random scheme selection commands

### DIFF
--- a/ColorSchemeSelector.py
+++ b/ColorSchemeSelector.py
@@ -1,16 +1,33 @@
 import sublime, sublime_plugin
 import os
 from glob import iglob
+from random import choice
 
 class SelectColorSchemeCommand(sublime_plugin.WindowCommand):
-    def run(self):
+    def run(self, **kwargs):
         color_schemes = self.get_color_schemes()
 
         def on_done(index):
             if index >= 0:
                 self.set_color_scheme(color_schemes[index][1])
+        
+        if kwargs.has_key('random'):
+            self.set_color_scheme(choice(color_schemes)[1])
+        elif kwargs.has_key('direction'):
+            self.move_color_scheme(kwargs['direction'], color_schemes)
+        else:
+            self.window.show_quick_panel(color_schemes, on_done)
 
-        self.window.show_quick_panel(color_schemes, on_done)
+    def move_color_scheme(self, direction, color_schemes):
+        current_scheme = self.load_settings().get('color_scheme')
+        current_index = [c[1] for c in color_schemes].index(current_scheme)
+        if direction == 'previous':
+            index = current_index - 1
+        elif direction == 'next':
+            index = current_index + 1 if current_index < len(color_schemes) else 0
+        else:
+            raise ValueError
+        self.set_color_scheme(color_schemes[index][1])
 
     # [[name, path]...]
     def get_color_schemes(self):
@@ -25,6 +42,7 @@ class SelectColorSchemeCommand(sublime_plugin.WindowCommand):
     def set_color_scheme(self, color_scheme_path):
         self.load_settings().set('color_scheme', color_scheme_path)
         sublime.save_settings('Preferences.sublime-settings')
+        sublime.status_message('SelectColorScheme: ' + color_scheme_path)
 
     def load_settings(self):
         return sublime.load_settings('Preferences.sublime-settings')

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -2,5 +2,20 @@
   {
     "caption": "ColorSchemeSelector: Select Color Scheme",
     "command": "select_color_scheme"
-  }
+  },
+  {
+		"caption": "ColorSchemeSelector: Random Color Scheme",
+		"command": "select_color_scheme",
+		"args": {"random": true}
+	},
+	{
+		"caption": "ColorSchemeSelector: Previous Color Scheme",
+		"command": "select_color_scheme",
+		"args": {"direction": "previous"}
+	},
+	{
+		"caption": "ColorSchemeSelector: Next Color Scheme",
+		"command": "select_color_scheme",
+		"args": {"direction": "next"}
+	}
 ]


### PR DESCRIPTION
I thought this plugin could benefit from some additional commands to browse through the generated color scheme list.
