### PR TITLE
Support new .sublime-color-scheme file type

### DIFF
--- a/ColorSchemeSelector.py
+++ b/ColorSchemeSelector.py
@@ -6,7 +6,7 @@ from random import choice
 class SelectColorSchemeCommand(sublime_plugin.WindowCommand):
     def run(self, **kwargs):
         if int(sublime.version()) > 3000:
-            color_schemes = sublime.find_resources("*.tmTheme")
+            color_schemes = sublime.find_resources("*.tmTheme") + sublime.find_resources("*.sublime-color-scheme")
         else:
             color_schemes = [
                 "All Hallow's Eve",

--- a/ColorSchemeSelector.py
+++ b/ColorSchemeSelector.py
@@ -64,7 +64,14 @@ class SelectColorSchemeCommand(sublime_plugin.WindowCommand):
 
     def current_scheme_index(self, color_schemes):
         current_scheme = self.load_settings().get('color_scheme')
-        return [c for c in color_schemes].index(current_scheme)
+        for idx, color_scheme in enumerate(color_schemes):
+            default_scheme = self.default_scheme_path(current_scheme)
+            if color_scheme in (current_scheme, default_scheme):
+                return idx
+        raise ValueError
+
+    def default_scheme_path(self, default_scheme_filename):
+        return os.path.join('Packages', 'Color Scheme - Default', default_scheme_filename)
 
     def set_color_scheme(self, color_scheme_path):
         self.load_settings().set('color_scheme', color_scheme_path)


### PR DESCRIPTION
Also handle the case where `color_scheme` is not a full path, but instead a name of a `.sublime-color-scheme` file in the `Color Scheme - Defaults` package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jugyo/sublimecolorschemeselector/13)
<!-- Reviewable:end -->
